### PR TITLE
Milestone 3: Friendship v2

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -18,6 +18,7 @@ class FriendshipsController < ApplicationController
   def accept
     @friend = User.find(params[:user_id])
     if current_user.confirm_friend(@friend)
+      Friendship.create(user_id: current_user.id, friend_id: @friend.id, status: 'confirmed')
       flash[:notice] = "You are now friends with #{@friend.name}!"
     else
       flash[:alert] = "Sorry, we couldn't process your request!"

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,7 @@ class PostsController < ApplicationController
   private
 
   def timeline_posts
-    @timeline_posts ||= Post.all.ordered_by_most_recent.includes(:user)
+    @timeline_posts = Post.all.ordered_by_most_recent
   end
 
   def post_params

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -8,26 +8,4 @@ module PostHelper
   def likes_count(post)
     post.likes
   end
-
-  def check_current_user_post(post)
-    post.user.id == current_user.id
-  end
-
-  def check_friends_post(post)
-    current_user.friends.pluck(:id).any?(post.user.id)
-  end
-
-  def check_post_owner(post)
-    check_current_user_post(post) || check_friends_post(post)
-  end
-
-  def show_friends_posts(posts)
-    posts.each do |post|
-      if check_post_owner(post)
-        render 'posts/post', post: post
-      end
-    end
-  end
-
-
 end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -8,4 +8,26 @@ module PostHelper
   def likes_count(post)
     post.likes
   end
+
+  def check_current_user_post(post)
+    post.user.id == current_user.id
+  end
+
+  def check_friends_post(post)
+    current_user.friends.pluck(:id).any?(post.user.id)
+  end
+
+  def check_post_owner(post)
+    check_current_user_post(post) || check_friends_post(post)
+  end
+
+  def show_friends_posts(posts)
+    posts.each do |post|
+      if check_post_owner(post)
+        render 'posts/post', post: post
+      end
+    end
+  end
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,7 @@ class User < ApplicationRecord
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
 
   def friends
-    friends_array = friendships.map { |f| f.friend if f.status == 'confirmed' }
-    inverse_friends = inverse_friendships.map { |f| f.user if f.status == 'confirmed' }
-    (friends_array + inverse_friends).compact
+    friendships.map { |f| f.friend if f.status == 'confirmed' }.compact
   end
 
   def pending_friends

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,6 +10,6 @@
     Recent posts
   </h3>
   <ul class="posts">
-    <%= render @timeline_posts %>
+    <%= show_friends_posts(@timeline_posts) %>
   </ul>
 </article>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,6 +10,7 @@
     Recent posts
   </h3>
   <ul class="posts">
-    <%= show_friends_posts(@timeline_posts) %>
+    <%= render @timeline_posts %>
   </ul>
 </article>
+

--- a/docs/code
+++ b/docs/code
@@ -1,0 +1,19 @@
+def check_current_user_post(post)
+    post.user.id == current_user.id
+  end
+
+  def check_friends_post(post)
+    current_user.friends.pluck(:id).any?(post.user.id)
+  end
+
+  def check_post_owner(post)
+    check_current_user_post(post) || check_friends_post(post)
+  end
+
+  def show_friends_posts(posts)
+    posts.each do |post|
+      if check_post_owner(post)
+        render '/posts/testing_posts', post: post
+      end
+    end
+  end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -43,4 +43,15 @@ RSpec.feature 'Friendships' do
     click_on 'Accept friendship'
     expect(page).to have_content("You are now friends with #{another_user.name}!")
   end
+
+  scenario 'when a user denies an invitation to a friendship' do
+    Friendship.create(user_id: 2, friend_id: 1, status: 'pending')
+    visit '/users/sign_in'
+    fill_in 'Email', with: 'yukihiro@mastsumoto.com'
+    fill_in 'Password', with: 'matsumoto'
+    click_on 'Log in'
+    visit '/users/1/friendships'
+    click_on 'Deny'
+    expect(page).to have_content("You just denied the invitation from #{another_user.name}!")
+  end
 end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -1,3 +1,6 @@
+# rubocop:disable Metrics/BlockLength
+# rubocop:disable Layout/LineLength
+
 require 'rails_helper'
 
 RSpec.describe Friendship, type: :model do
@@ -21,7 +24,6 @@ RSpec.feature 'Friendships' do
     current_user
     another_user
   end
-
 
   scenario 'when a user gets invited to a friendship' do
     visit '/users/sign_in'
@@ -55,3 +57,6 @@ RSpec.feature 'Friendships' do
     expect(page).to have_content("You just denied the invitation from #{another_user.name}!")
   end
 end
+
+# rubocop:enable Metrics/BlockLength
+# rubocop:enable Layout/LineLength

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -14,16 +14,23 @@ RSpec.describe Friendship, type: :model do
 end
 
 RSpec.feature 'Friendships' do
-  let(:current_user) { User.create(name: 'Yukihiro Matsumo', email: 'yukihiro@mastsumoto.com', password: 'matsumoto') }
+  let(:current_user) { User.create(id: 1, name: 'Yukihiro Matsumo', email: 'yukihiro@mastsumoto.com', password: 'matsumoto') }
 
-  let(:another_user) { User.create(name: 'Yubei Miyazaki', email: 'yubei@miyazaki.com', password: 'miyazaki') }
+  let(:another_user) { User.create(id: 2, name: 'Yubei Miyazaki', email: 'yubei@miyazaki.com', password: 'miyazaki') }
+
+  let(:third_user) { User.create(id: 3, name: 'luigi Mahrez', email: 'luigi@mahrez.com', password: 'mahrez') }
+  let(:fourth_user) { User.create(id: 4, name: 'Jorge Martin', email: 'jorge@martin.com', password: 'martin') }
+
+  let(:invitation) { Friendship.create(user_id: 3, friend_id: 4, status: 'pending')}
 
   before(:each) do
     current_user
-  end
-  before(:each) do
     another_user
+    third_user
+    fourth_user
+    invitation
   end
+
 
   scenario 'when a user gets invited to a friendship' do
     visit '/users/sign_in'
@@ -31,7 +38,20 @@ RSpec.feature 'Friendships' do
     fill_in 'Password', with: 'matsumoto'
     click_on 'Log in'
     visit '/users'
-    click_on 'Invite to friendship'
+    click_link 'users/2/friendships'
+    # click_on 'Invite to friendship'
     expect(page).to have_content("Your friend request to #{another_user.name} is sent!")
+  end
+
+  scenario 'when a user accepts an invitation to a friendship' do
+
+    visit '/users/sign_in'
+    fill_in 'Email', with: 'jorge@martin.com'
+    fill_in 'Password', with: 'martin'
+    click_on 'Log in'
+    visit '/users/4/friendships'
+    expect(page).to have_content('Pending requests')
+    # click_on 'Accept friendship'
+    # expect(page).to have_content("You're now friends with to #{current_user.name}!")
   end
 end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -15,20 +15,11 @@ end
 
 RSpec.feature 'Friendships' do
   let(:current_user) { User.create(id: 1, name: 'Yukihiro Matsumo', email: 'yukihiro@mastsumoto.com', password: 'matsumoto') }
-
   let(:another_user) { User.create(id: 2, name: 'Yubei Miyazaki', email: 'yubei@miyazaki.com', password: 'miyazaki') }
-
-  let(:third_user) { User.create(id: 3, name: 'luigi Mahrez', email: 'luigi@mahrez.com', password: 'mahrez') }
-  let(:fourth_user) { User.create(id: 4, name: 'Jorge Martin', email: 'jorge@martin.com', password: 'martin') }
-
-  let(:invitation) { Friendship.create(user_id: 3, friend_id: 4, status: 'pending')}
 
   before(:each) do
     current_user
     another_user
-    third_user
-    fourth_user
-    invitation
   end
 
 
@@ -38,20 +29,18 @@ RSpec.feature 'Friendships' do
     fill_in 'Password', with: 'matsumoto'
     click_on 'Log in'
     visit '/users'
-    click_link 'users/2/friendships'
-    # click_on 'Invite to friendship'
+    click_on 'Invite to friendship'
     expect(page).to have_content("Your friend request to #{another_user.name} is sent!")
   end
 
   scenario 'when a user accepts an invitation to a friendship' do
-
+    Friendship.create(user_id: 2, friend_id: 1, status: 'pending')
     visit '/users/sign_in'
-    fill_in 'Email', with: 'jorge@martin.com'
-    fill_in 'Password', with: 'martin'
+    fill_in 'Email', with: 'yukihiro@mastsumoto.com'
+    fill_in 'Password', with: 'matsumoto'
     click_on 'Log in'
-    visit '/users/4/friendships'
-    expect(page).to have_content('Pending requests')
-    # click_on 'Accept friendship'
-    # expect(page).to have_content("You're now friends with to #{current_user.name}!")
+    visit '/users/1/friendships'
+    click_on 'Accept friendship'
+    expect(page).to have_content("You are now friends with #{another_user.name}!")
   end
 end


### PR DESCRIPTION
### Friendship v2

In this milestone we did: 

- change the `friends` method in the user model so it looks only at records where the user is equal to user_id
- change the `accept` method in the friendships controller so it adds a new record in the friendships table where the user who accepted the friendship corresponds to user_id and the user who invited him corresponds to the friend_id (so now every confirmed friendship will have two separate records for it)